### PR TITLE
build(postgresql): pull chart via OCI (unblock PostgreSQL 17.3)

### DIFF
--- a/infrastructure/base/sources/bitnami.yaml
+++ b/infrastructure/base/sources/bitnami.yaml
@@ -1,7 +1,8 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: HelmRepository
 metadata:
   name: bitnami
 spec:
+  type: oci
   interval: 36h0m0s
-  url: https://charts.bitnami.com/bitnami
+  url: oci://registry-1.docker.io/bitnamicharts


### PR DESCRIPTION
## What

Convert the `bitnami` Flux `HelmRepository` (`infrastructure/base/sources/bitnami.yaml`) from an HTTP-type source to an **OCI** source (`source.toolkit.fluxcd.io/v1beta2`, `type: oci`, `url: oci://registry-1.docker.io/bitnamicharts`).

## Why

The tesla `postgresql` HelmRelease already pins chart `16.4.11` (PostgreSQL **17.3.0**) on `master`, but it is **not deploying** — the cluster is stuck on chart `16.2.0` (PostgreSQL 17.0.0). Flux fails with:

```
ChartPullError: oci://registry-1.docker.io/bitnamicharts/postgresql:16.4.11 unsupported protocol scheme "oci"
```

Bitnami deprecated the classic HTTP chart repo (`charts.bitnami.com/bitnami`); its index now embeds `oci://` download URLs for newer chart versions. The HTTP-type source feeds that `oci://` URL to source-controller's HTTP client, which rejects the scheme. Converting the source to OCI type fixes the pull.

## Notes

- **No Flux upgrade required** — the running `source-controller` already serves `HelmRepository` `v1beta2` with `type: ["default","oci"]`.
- **No PostgreSQL data migration** — the DB is already on PG 17.0, so this is an in-place 17.0 → 17.3 minor upgrade on the existing PVC.
- `apiVersion` is `v1beta2` (not `v1`) — `HelmRepository` has no `v1` in the current controller.
- No changes to `apps/prod/tesla/release.yaml` / `values.yaml`; the `bitnamilegacy/postgresql` image override still applies and the inherited tag `17.3.0-debian-12-r3` exists in the legacy repo.
- Only `tesla/release.yaml` consumes the `bitnami` source, so blast radius is one release. The in-cluster `HelmRepository` will become an OCI static object with an empty `.status` (expected for OCI type).

## Verify after merge

- `kubectl -n tesla get helmrelease postgresql` → `Ready=True`, revision `16.4.11`
- postgresql pod image → `docker.io/bitnamilegacy/postgresql:17.3.0-debian-12-r3`
- `psql -c 'select version();'` reports 17.3; teslamate healthy

## Follow-up (separate, not in this PR)

The Flux controllers are 2022-era pre-GA. A staged upgrade to Flux **v2.2.3** (newest supporting k8s 1.26) is planned as decoupled stacked PRs for maintenance/CVEs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)