### PR TITLE
build(postgresql): allow bitnamilegacy image (final piece for 17.3)

### DIFF
--- a/apps/prod/tesla/values.yaml
+++ b/apps/prod/tesla/values.yaml
@@ -1,3 +1,10 @@
+# Bitnami charts >= 16.x hard-reject non-standard images (we use the
+# bitnamilegacy repo) unless image verification is explicitly disabled.
+# See bitnami/charts#30850.
+global:
+  security:
+    allowInsecureImages: true
+
 image:
   # GOD DAMN Bitnami
   repository: bitnamilegacy/postgresql


### PR DESCRIPTION
## What
Add `global.security.allowInsecureImages: true` to `apps/prod/tesla/values.yaml`.

## Why
With Flux upgraded (source-controller now pulls the OCI chart) the `postgresql` HelmRelease finally reached chart **16.4.11** — but the Helm *upgrade* fails:

```
UpgradeFailed: ⚠ ERROR: Original containers have been substituted for unrecognized ones.
Unrecognized images:
  - docker.io/bitnamilegacy/postgresql:17.3.0-debian-12-r3
... set the global parameter 'global.security.allowInsecureImages' to true.
```

Bitnami charts ≥16.x hard-reject non-standard images. We deliberately pin `bitnamilegacy/postgresql` (post-relicensing), so we must opt in. Ref bitnami/charts#30850.

## Effect
Unblocks the in-place **17.0.0 → 17.3.0** upgrade (same major version, existing PVC — no data migration).

## Verify after merge
- `kubectl -n tesla get helmrelease postgresql` → `Ready=True`, revision `16.4.11`
- pod image → `bitnamilegacy/postgresql:17.3.0-debian-12-r3`; `select version();` → 17.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)