### PR TITLE
build(teslamate): upgrade to v4.0.1

### DIFF
--- a/apps/prod/tesla/grafana.yaml
+++ b/apps/prod/tesla/grafana.yaml
@@ -28,7 +28,7 @@ spec:
           ports:
             - containerPort: 3000
           imagePullPolicy: IfNotPresent
-          image: teslamate/grafana:1.33.0
+          image: teslamate/grafana:4.0.1
           envFrom:
             - configMapRef:
                 name: teslamate

--- a/apps/prod/tesla/teslamate.yaml
+++ b/apps/prod/tesla/teslamate.yaml
@@ -38,7 +38,7 @@ spec:
           ports:
             - containerPort: 4000
           imagePullPolicy: IfNotPresent
-          image: teslamate/teslamate:1.33.0
+          image: teslamate/teslamate:4.0.1
           envFrom:
             - configMapRef:
                 name: teslamate


### PR DESCRIPTION
Bumps TeslaMate + companion Grafana from \`1.33.0\` → \`4.0.1\` (native Deployments, image pin only).

## Why now
TeslaMate **v2.0.0 requires PostgreSQL 16.7 / 17.3+** (bundled \`earthdistance\` extension bumped to v1.2) and refuses to start otherwise. The cluster now runs PG 17.3, so the requirement is satisfied.

## Upgrade path
- 1.x → 2.0 is a **direct** step (Ecto migrations run cumulatively on boot).
- v3.0 = license change only (MIT → AGPLv3).
- v4.0 drops ARMv7; this cluster is **arm64** ✓.
- Both \`4.0.1\` tags verified present and multi-arch.

The v2.0 migration upgrades \`earthdistance\`/\`cube\` — needs superuser. TeslaMate connects as \`DATABASE_USER: postgres\` (Bitnami admin), so it succeeds.

## ⚠️ Parked draft — do not merge yet
The migration is **irreversible** (schema + extension changes). **Take a \`pg_dump\` backup of the \`teslamate\` DB immediately before merging**, then merge → Flux rolls both Deployments.

## Post-roll checks
- \`teslamate\` boots, runs migrations to completion, no crashloop.
- Web UI loads; may need a **Tesla re-sign-in** (v4 token/Owner-API change).
- Grafana: if panels show "No Data", re-save the TeslaMate datasource.

## Rollback
Revert this commit **and** restore the pre-upgrade \`pg_dump\` (drop/recreate \`teslamate\` DB, \`psql < dump\`) — 1.33.0 cannot read the 4.x schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)