### PR TITLE
docs: disable only traefik in bootstrap and align CLAUDE.md with cluster

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-> This is a **public** repository. Never commit or document secrets, private IPs, internal hostnames, or domains.
+> This is a **public** repository. Never commit or document secrets, public hostnames, or domains. Internal RFC1918 IPs (e.g. the `172.16.x.x` addresses in `k3sup/home-cluster/install.sh`) are non-routable and fine to keep.
 
 ## What this is
 
@@ -13,6 +13,9 @@ A Flux v2 GitOps monorepo for a personal Kubernetes homelab. Cluster state is de
 - `clusters/<cluster>/` — one dir per cluster. Currently a single live cluster, `home`, which holds `flux-system/` (Flux controllers + GitRepository source) and Flux `Kustomization` CRDs: `infrastructure.yaml`, `apps.yaml`. These wire cluster → repo paths and set ordering via `dependsOn` (apps depend on infrastructure).
 - `apps/` — application workloads. `base/` shared bases, `prod/` deployed apps, `no-deployment/` defined-but-inactive.
 - `infrastructure/` — core services (cert-manager, nginx ingress, longhorn, etc.). `base/` + per-cluster overlays. `infrastructure/base/sources/` defines Flux `HelmRepository` CRDs (the chart repos everything pulls from).
+- `k3sup/home-cluster/install.sh` — one-off cluster bootstrap (k3s via k3sup). The actual `k3sup install`/`join` commands are **commented out**, so it's a historical record, not run on deploys. It disables only k3s's built-in `traefik` (nginx-ingress replaces it). k3s's **servicelb** (Klipper — `svclb-*` pods back the nginx `LoadBalancer` Service) and **local-storage** (the default `local-path` StorageClass / `rancher.io/local-path` provisioner, which backs the app PVCs — e.g. tesla's) are **kept**. longhorn is defined but commented out of the infra allow-list, so it is not running.
+
+> `README.md` is stale — it describes an older multi-cluster layout (`clusters/prod`, `raspberry-pi-cluster`, drone sources, etc.) that no longer exists. Trust the actual tree and this file over it.
 
 ## How deployment works (Flux DAG)
 
@@ -23,6 +26,13 @@ infrastructure  →  apps
 ```
 
 So a change to a shared source or infra component can gate app reconciliation. Any cluster-scoped differences are handled by per-cluster overlay dirs, not branches.
+
+The `home` cluster reconciles **exactly** `./apps/prod` and `./infrastructure/prod`, and the two roots work differently:
+
+- `apps/prod/` has **no** root `kustomization.yaml` — Flux recurses every subdir, so dropping a new app dir under `apps/prod/` makes it live automatically.
+- `infrastructure/prod/kustomization.yaml` composes `../base`, and `infrastructure/base/kustomization.yaml` is an **explicit allow-list** of components. A component only deploys if listed there (e.g. `longhorn` is currently commented out, so it is *not* running despite existing in the tree).
+
+Everything outside those two roots is inert: `apps/base/`, `apps/no-deployment/`, `infrastructure/raspberry-pi-cluster/`, and any base component not listed in `infrastructure/base/kustomization.yaml` deploy nothing.
 
 ## App structure
 
@@ -37,7 +47,7 @@ Each app is a Kustomize dir = one namespace. Three styles, often mixed in one di
 1. Work in `apps/prod/<app>/` (or the relevant cluster overlay).
 2. Provide `namespace.yaml` + workload manifests and/or `release.yaml`.
 3. List everything in `kustomization.yaml` (set `namespace:`; use `configMapGenerator` for Helm values).
-4. Ensure the parent cluster `apps.yaml` path already covers the dir (usually `./apps/prod`).
+4. For apps, creating the dir under `apps/prod/` is enough (Flux recurses it — no root list to edit). For infra, add the component to `infrastructure/base/kustomization.yaml`'s `resources:` or it won't deploy.
 5. Match existing conventions (below). Commit — Flux deploys.
 
 ## Conventions

--- a/k3sup/home-cluster/install.sh
+++ b/k3sup/home-cluster/install.sh
@@ -28,7 +28,9 @@ do
   ssh root@$ip "apt-get install curl vim htop lm-sensors open-iscsi sudo -y"
 done
 
-EXTRA_ARGS="--write-kubeconfig-mode 0664 --disable traefik,servicelb local-storage --tls-san $KUBE_VIP"
+# Only traefik is disabled — servicelb (Klipper, backs the nginx LoadBalancer)
+# and local-storage (the local-path provisioner backing app PVCs) are kept.
+EXTRA_ARGS="--write-kubeconfig-mode 0664 --disable traefik --tls-san $KUBE_VIP"
 
 #k3sup install \
 # --ip $MASTER_ONE \


### PR DESCRIPTION
## What

Corrects the k3s bootstrap and docs to match what the live cluster actually runs.

The `k3sup/home-cluster/install.sh` bootstrap *intended* to disable k3s's built-in `traefik`, `servicelb`, and `local-storage`. But the running cluster shows otherwise:

- `svclb-ingress-nginx-controller-*` pods → **servicelb (Klipper) is active**, backing the nginx `LoadBalancer` Service.
- `local-path (default)` StorageClass (`rancher.io/local-path`) → **local-storage is active**, and it's what backs app PVCs (e.g. tesla's 25Gi Postgres volume). Nothing else in the repo provides that provisioner.

Only `traefik` is genuinely gone (nginx-ingress replaces it).

## Changes

- `install.sh`: narrow `--disable` to `traefik` only, with a comment noting servicelb and local-storage are intentionally kept. (Commands remain commented out — this is a historical bootstrap record, not run on deploys.)
- `CLAUDE.md`: describe the actual built-in state; also folds in prior pending doc-accuracy edits (public-repo internal-IP guidance, Flux DAG reconcile roots, stale-README note).

No change to the running cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)