### PR TITLE
feat(hyundai-bluelink-mqtt): add smart-home deployment with kube token store

### DIFF
--- a/apps/prod/smart-home/hyundai-bluelink-mqtt.yaml
+++ b/apps/prod/smart-home/hyundai-bluelink-mqtt.yaml
@@ -1,0 +1,121 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hyundai-bluelink-mqtt
+data:
+  MODE: "live"
+  MQTT_BROKER_URL: "mqtt://mqtt.home.gsdev.me:1883"
+  TOKEN_STORE: "kube"
+  TOKEN_SECRET_NAME: "hyundai-bluelink-mqtt-token"
+  HEALTH_ADDR: ":8080"
+  # defaults left unset: POLL_INTERVAL(45m), MQTT_TOPIC_PREFIX(hyundai_bluelink),
+  # HA_DISCOVERY_PREFIX(homeassistant), LOG_FORMAT(json). BLUELINK_VIN/PIN only if needed.
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: hyundai-bluelink-mqtt
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: hyundai-bluelink-mqtt-token
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames: ["hyundai-bluelink-mqtt-token"]
+    verbs: ["get", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: hyundai-bluelink-mqtt-token
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: hyundai-bluelink-mqtt-token
+subjects:
+  - kind: ServiceAccount
+    name: hyundai-bluelink-mqtt
+---
+# Token store the app mutates at runtime via the K8s API (TOKEN_STORE=kube).
+# INVARIANT: never add data:/stringData: here. Flux uses server-side apply, so with
+# no data keys the kustomize-controller field manager owns none of them; the app's
+# field manager owns access_token/refresh_token/device_id/valid_until and SSA leaves
+# those intact on reconcile. Adding data: would let Flux clobber the persisted tokens.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: hyundai-bluelink-mqtt-token
+type: Opaque
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hyundai-bluelink-mqtt
+  labels:
+    app: hyundai-bluelink-mqtt
+spec:
+  replicas: 1
+  revisionHistoryLimit: 2
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: hyundai-bluelink-mqtt
+  template:
+    metadata:
+      labels:
+        app: hyundai-bluelink-mqtt
+    spec:
+      serviceAccountName: hyundai-bluelink-mqtt
+      automountServiceAccountToken: true
+      terminationGracePeriodSeconds: 60
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              preference:
+                matchExpressions:
+                  - key: kubernetes.io/arch
+                    operator: In
+                    values: ["arm64"]
+      containers:
+        - name: hyundai-bluelink-mqtt
+          image: ghcr.io/gsdevme/hyundai-bluelink-mqtt:v1.0.0
+          imagePullPolicy: IfNotPresent
+          envFrom:
+            - configMapRef:
+                name: hyundai-bluelink-mqtt
+            - secretRef:
+                name: hyundai-bluelink-mqtt
+          ports:
+            - containerPort: 8080
+              name: health
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            periodSeconds: 30
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8080
+            initialDelaySeconds: 15
+            periodSeconds: 30
+            failureThreshold: 10
+          resources:
+            limits:
+              memory: "128Mi"
+              cpu: "100m"
+            requests:
+              memory: "128Mi"
+              cpu: "100m"
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]

--- a/apps/prod/smart-home/kustomization.yaml
+++ b/apps/prod/smart-home/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
 #  - unifi-poller.yaml
   - solis-inverter-manager.yaml
 #  - solismon3.yaml
+  - hyundai-bluelink-mqtt.yaml


### PR DESCRIPTION
## What

Deploys [`gsdevme/hyundai-bluelink-mqtt`](https://github.com/gsdevme/hyundai-bluelink-mqtt) into the `home` cluster's `smart-home` namespace. It polls the Hyundai Bluelink EU API and publishes vehicle state to the MQTT broker with Home Assistant discovery.

## Design

- **Single writer**: `replicas: 1`, `Recreate` strategy — the app owns a single token store and can't tolerate concurrent writers.
- **Token persistence (`TOKEN_STORE=kube`)**: the app mutates a Kubernetes Secret at runtime via the API. A committed but **empty** `hyundai-bluelink-mqtt-token` Secret (no `data:`) gives Flux a shell to create, while server-side apply ensures the kustomize-controller field manager never owns the token keys — so reconciles never clobber the app-written `access_token`/`refresh_token`/`device_id`/`valid_until`. Scoped RBAC (`resourceNames` on the one Secret, `get`/`update`/`patch`) lets the pod write only its own token.
  - **Invariant**: never add `data:`/`stringData:` to the committed token Secret.
- **MQTT**: anonymous to `mqtt://mqtt.home.gsdev.me:1883` (LAN-only, established convention across the repo).
- **Image**: pinned `ghcr.io/gsdevme/hyundai-bluelink-mqtt:v1.0.0` (multi-arch, public).
- arm64 **preferred** (soft) affinity, distroless nonroot securityContext, health probes on `:8080`.

No ingress, no Service — Deployment only.

## Files

- **New** `apps/prod/smart-home/hyundai-bluelink-mqtt.yaml` — ConfigMap, ServiceAccount, Role, RoleBinding, empty token Secret, Deployment.
- **Edit** `apps/prod/smart-home/kustomization.yaml` — added to the explicit resource list.

## Not in this PR (applied manually)

Real Bluelink credentials live in a local, gitignored `apps/prod/smart-home/secrets.yaml` (`BLUELINK_USERNAME`/`BLUELINK_PASSWORD`), applied with `kubectl apply` — not managed by Flux.

## Verification

- `kustomize build apps/prod/smart-home` renders all objects namespaced to `smart-home`; token Secret has no data keys.
- Post-merge: apply local credentials, confirm pod Running + Bluelink auth + MQTT connect, and that the token Secret populates and **survives** a `flux reconcile kustomization apps`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)