### PR TITLE
build(hyundai-bluelink-mqtt): bump image to v1.0.1

### DIFF
--- a/apps/prod/smart-home/hyundai-bluelink-mqtt.yaml
+++ b/apps/prod/smart-home/hyundai-bluelink-mqtt.yaml
@@ -82,7 +82,7 @@ spec:
                     values: ["arm64"]
       containers:
         - name: hyundai-bluelink-mqtt
-          image: ghcr.io/gsdevme/hyundai-bluelink-mqtt:v1.0.0
+          image: ghcr.io/gsdevme/hyundai-bluelink-mqtt:v1.0.1
           imagePullPolicy: IfNotPresent
           envFrom:
             - configMapRef:


### PR DESCRIPTION
Bumps the `hyundai-bluelink-mqtt` Deployment image from `v1.0.0` to `v1.0.1` ([release notes](https://github.com/gsdevme/hyundai-bluelink-mqtt/releases/tag/v1.0.1)).

Config, RBAC, and the token-store setup are unchanged. Flux reconciles the rollout after merge (~10m, or `flux reconcile kustomization apps --with-source`); `Recreate` strategy means the single replica restarts in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)