### PR TITLE
feat(hyundai-bluelink-mqtt): set DISTANCE_UNIT to mi

### DIFF
--- a/apps/prod/smart-home/hyundai-bluelink-mqtt.yaml
+++ b/apps/prod/smart-home/hyundai-bluelink-mqtt.yaml
@@ -8,6 +8,7 @@ data:
   TOKEN_STORE: "kube"
   TOKEN_SECRET_NAME: "hyundai-bluelink-mqtt-token"
   HEALTH_ADDR: ":8080"
+  DISTANCE_UNIT: "mi"
   # defaults left unset: POLL_INTERVAL(45m), MQTT_TOPIC_PREFIX(hyundai_bluelink),
   # HA_DISCOVERY_PREFIX(homeassistant), LOG_FORMAT(json). BLUELINK_VIN/PIN only if needed.
 ---


### PR DESCRIPTION
Adds `DISTANCE_UNIT: "mi"` to the `hyundai-bluelink-mqtt` ConfigMap so vehicle distances (range, odometer) are published in miles rather than the default.

Flux reconciles after merge (~10m, or `flux reconcile kustomization apps --with-source`); the ConfigMap change triggers a pod restart via the `Recreate` strategy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)